### PR TITLE
Add a link to the settings page in the popup

### DIFF
--- a/popup.css
+++ b/popup.css
@@ -14,6 +14,7 @@
 	--gray-dark: #bfbfc9;
 
 	--outer-padding: 5px;
+	--button-paddings: 3px 6px;
 	--border-radius: 5px;
 }
 
@@ -76,7 +77,7 @@ body {
 	align-items: center;
 	gap: 3px;
 	font: inherit;
-	padding: 3px 6px;
+	padding: var(--button-paddings);
 	background-color: var(--card-background);
 	border: 1px solid var(--border-color);
 	border-radius: var(--border-radius);
@@ -109,11 +110,27 @@ body {
 	height: 1em;
 }
 
-.error {
+.api-key-missing {
 	display: none;
+	flex-direction: column;
 	justify-content: center;
 	align-items: center;
-	height: 150px;
+	gap: 10px;
+	padding: var(--outer-padding);
+	min-height: 150px;
+}
+
+.api-key-missing button {
+	font: inherit;
+	padding: var(--button-paddings);
+	background-color: var(--card-background);
+	border: 1px solid var(--border-color);
+	border-radius: var(--border-radius);
+	cursor: pointer;
+}
+
+.api-key-missing button:hover {
+	background-color: var(--card-background-hover);
 }
 
 @keyframes rotate {
@@ -221,7 +238,7 @@ li:last-of-type {
 .item .buttons button {
 	display: flex;
 	font: inherit;
-	padding: 3px 6px;
+	padding: var(--button-paddings);
 	background-color: var(--card-background);
 	border: 1px solid var(--border-color);
 	border-radius: var(--border-radius);
@@ -268,7 +285,7 @@ legend {
 #labels-page #buttons button {
 	display: flex;
 	font: inherit;
-	padding: 3px 6px;
+	padding: var(--button-paddings);
 	background-color: var(--card-background);
 	border: 1px solid var(--border-color);
 	border-radius: var(--border-radius);

--- a/popup.html
+++ b/popup.html
@@ -84,7 +84,11 @@
 			</svg>
 			Loading…
 		</div>
-		<div class="error" id="error"></div>
+		<div class="api-key-missing" id="api-key-missing">
+			Please add your Omnivore API key<br />
+			in the extension settings.
+			<button type="button" class="open-settings">Open Settings</button>
+		</div>
 		<div class="content" id="content"></div>
 		<div class="labels-page" id="labels-page" style="display: none">
 			<fieldset>

--- a/src/popup/index.js
+++ b/src/popup/index.js
@@ -1,3 +1,4 @@
+import browser from 'webextension-polyfill'
 import { addLink, loadItems, loadLabels } from '../services/api'
 import { loadApiKey } from '../services/storage'
 import { getActiveTab, openTab } from '../services/tabs'
@@ -7,16 +8,14 @@ async function initialize() {
 	await reloadItems()
 }
 
-function showError(message) {
-	const error = document.getElementById('error')
-	error.innerText = message
-	error.style = 'display: flex;'
+function showApiKeyMissingPage() {
+	const page = document.getElementById('api-key-missing')
+	page.style = 'display: flex;'
 }
 
-function resetError() {
-	const error = document.getElementById('error')
-	error.innerText = ''
-	error.style = 'display: none;'
+function hideApiKeyMissingPage() {
+	const page = document.getElementById('api-key-missing')
+	page.style = 'display: none;'
 }
 
 function showLoadingState() {
@@ -32,10 +31,10 @@ function hideLoadingState() {
 async function reloadItems() {
 	const apiKey = await loadApiKey()
 	if (!apiKey) {
-		showError('No API key found! Please check the extension settings.')
+		showApiKeyMissingPage()
 		return
 	}
-	resetError()
+	hideApiKeyMissingPage()
 	showLoadingState()
 	const content = document.getElementById('content')
 	content.textContent = ''
@@ -73,6 +72,10 @@ document.addEventListener('click', async (event) => {
 	}
 	if (element.classList.contains('open-omnivore')) {
 		openTab('https://omnivore.app/')
+		window.close()
+	}
+	if (element.classList.contains('open-settings')) {
+		browser.runtime.openOptionsPage()
 		window.close()
 	}
 	element.removeAttribute('disabled')


### PR DESCRIPTION
Revamps the "error" page to be a bit more helpful and have a link to the settings (where users need to enter their Omnivore API key).

![Bildschirmfoto 2023-10-20 um 16 22 02](https://github.com/herrherrmann/omnivore-list-popup/assets/6429568/15030f60-a7a4-47bd-bb0a-001033587626)
