### PR TITLE
Add customizable search query, error handling, and empty state

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ If you have ideas or issues, please get in touch! You can either use [GitHub iss
 
 - [ ] Improve onboarding, e.g. make it possible to enter API key in popup
 - [ ] Improve error handling
+- [ ] Use Omnivore’s `savePage` API instead of `saveUrl` (to capture page content directly)
 - [ ] Internationalization
 - [ ] Cache list items locally for offline usage
 - [ ] Highlight the popup button if the current page is added to Omnivore

--- a/options.css
+++ b/options.css
@@ -40,7 +40,7 @@ label {
 input {
 	--padding: 6px;
 	display: block;
-	min-width: calc(36ch + 2 * var(--padding) + 2px);
+	min-width: 300px;
 	padding: var(--padding);
 	background-color: var(--background-color);
 	border: 1px solid var(--text-color-secondary);
@@ -50,6 +50,7 @@ input {
 }
 
 input#api-key {
+	min-width: calc(36ch + 2 * var(--padding) + 2px);
 	font-family: var(--font-family-mono);
 }
 

--- a/options.css
+++ b/options.css
@@ -34,7 +34,7 @@ form {
 
 label {
 	display: block;
-	margin-bottom: 10px;
+	margin-bottom: 15px;
 }
 
 input {
@@ -43,7 +43,7 @@ input {
 	min-width: 300px;
 	padding: var(--padding);
 	background-color: var(--background-color);
-	border: 1px solid var(--text-color-secondary);
+	border: 1px solid var(--border-color);
 	border-radius: var(--border-radius);
 	margin-top: 3px;
 	font: inherit;

--- a/options.html
+++ b/options.html
@@ -18,6 +18,15 @@
 				</small>
 				<input type="text" id="api-key" name="api-key" />
 			</label>
+			<label>
+				Search Query
+				<small>
+					(<a href="https://docs.omnivore.app/using/search.html" target="_blank"
+						>More info on search queries</a
+					> – default: <code>in:inbox</code>)
+				</small>
+				<input type="text" id="search-query" name="search-query" />
+			</label>
 			<button type="submit">Save</button>
 			<span class="message" id="message"></span>
 		</form>

--- a/popup.css
+++ b/popup.css
@@ -60,11 +60,13 @@ body {
 }
 
 .api-key-missing,
-.error {
+.error,
+.no-items {
 	display: none;
 	flex-direction: column;
 	justify-content: center;
 	align-items: center;
+	text-align: center;
 	gap: 10px;
 	padding: var(--outer-padding);
 	min-height: 150px;

--- a/popup.css
+++ b/popup.css
@@ -59,7 +59,8 @@ body {
 	height: 1em;
 }
 
-.api-key-missing {
+.api-key-missing,
+.error {
 	display: none;
 	flex-direction: column;
 	justify-content: center;
@@ -69,7 +70,8 @@ body {
 	min-height: 150px;
 }
 
-.api-key-missing button {
+.api-key-missing button,
+.error button {
 	font: inherit;
 	padding: var(--button-paddings);
 	background-color: var(--card-background);
@@ -78,7 +80,8 @@ body {
 	cursor: pointer;
 }
 
-.api-key-missing button:hover {
+.api-key-missing button:hover,
+.error button:hover {
 	background-color: var(--card-background-hover);
 }
 
@@ -263,8 +266,8 @@ legend {
 
 #labels-page #labels .label label .dot {
 	border-radius: 50%;
-	flex: 0 0 0.70em;
-	height: 0.70em;
+	flex: 0 0 0.7em;
+	height: 0.7em;
 }
 
 #labels-page #footer {

--- a/popup.html
+++ b/popup.html
@@ -85,6 +85,28 @@
 			</svg>
 			Loading…
 		</div>
+		<div class="error" id="error">
+			<svg
+				xmlns="http://www.w3.org/2000/svg"
+				width="24"
+				height="24"
+				viewBox="0 0 24 24"
+				fill="none"
+				stroke="currentColor"
+				stroke-width="2"
+				stroke-linecap="round"
+				stroke-linejoin="round"
+				class="lucide lucide-badge-alert"
+			>
+				<path
+					d="M3.85 8.62a4 4 0 0 1 4.78-4.77 4 4 0 0 1 6.74 0 4 4 0 0 1 4.78 4.78 4 4 0 0 1 0 6.74 4 4 0 0 1-4.77 4.78 4 4 0 0 1-6.75 0 4 4 0 0 1-4.78-4.77 4 4 0 0 1 0-6.76Z"
+				/>
+				<line x1="12" x2="12" y1="8" y2="12" />
+				<line x1="12" x2="12.01" y1="16" y2="16" />
+			</svg>
+			Error while fetching data.<br />Please check your extension settings.
+			<button type="button" class="open-settings">Open Settings</button>
+		</div>
 		<div class="api-key-missing" id="api-key-missing">
 			Please add your Omnivore API key<br />
 			in the extension settings.

--- a/popup.html
+++ b/popup.html
@@ -112,6 +112,26 @@
 			in the extension settings.
 			<button type="button" class="open-settings">Open Settings</button>
 		</div>
+		<div class="no-items" id="no-items">
+			<svg
+				xmlns="http://www.w3.org/2000/svg"
+				width="24"
+				height="24"
+				viewBox="0 0 24 24"
+				fill="none"
+				stroke="currentColor"
+				stroke-width="2"
+				stroke-linecap="round"
+				stroke-linejoin="round"
+				class="lucide lucide-search-x"
+			>
+				<path d="m13.5 8.5-5 5" />
+				<path d="m8.5 8.5 5 5" />
+				<circle cx="11" cy="11" r="8" />
+				<path d="m21 21-4.3-4.3" />
+			</svg>
+			No items found.
+		</div>
 		<div class="content" id="content"></div>
 		<div class="labels-page" id="labels-page" style="display: none">
 			<fieldset>

--- a/src/options/index.js
+++ b/src/options/index.js
@@ -1,9 +1,9 @@
-import { loadApiKey, saveApiKey } from '../services/storage'
+import { loadSetting, saveSetting } from '../services/storage'
 
 const apiKeyInputSelector = '#api-key'
 
 async function restoreOptions() {
-	const apiKey = await loadApiKey()
+	const apiKey = await loadSetting('apiKey')
 	const apiKeyInput = document.querySelector(apiKeyInputSelector)
 	apiKeyInput.value = apiKey || ''
 	validateInput(apiKey)
@@ -12,7 +12,7 @@ async function restoreOptions() {
 async function saveOptions(event) {
 	event.preventDefault()
 	const apiKey = document.querySelector(apiKeyInputSelector).value
-	await saveApiKey(apiKey)
+	await saveSetting('apiKey', apiKey)
 	validateInput(apiKey)
 	const messageElement = document.querySelector('#message')
 	messageElement.classList.add('success')

--- a/src/options/index.js
+++ b/src/options/index.js
@@ -1,19 +1,34 @@
 import { loadSetting, saveSetting } from '../services/storage'
 
 const apiKeyInputSelector = '#api-key'
+const searchQueryInputSelector = '#search-query'
 
 async function restoreOptions() {
-	const apiKey = await loadSetting('apiKey')
-	const apiKeyInput = document.querySelector(apiKeyInputSelector)
-	apiKeyInput.value = apiKey || ''
-	validateInput(apiKey)
+	const apiKey = await restoreInput('apiKey', apiKeyInputSelector)
+	validateInput(apiKey, apiKeyInputSelector)
+	await restoreInput('searchQuery', searchQueryInputSelector)
+}
+
+async function restoreInput(settingKey, inputSelector) {
+	const settingValue = (await loadSetting(settingKey)) || ''
+	const input = document.querySelector(inputSelector)
+	input.value = settingValue
+	return settingValue
+}
+
+function validateInput(settingValue, inputSelector) {
+	const isValid = !!settingValue
+	const input = document.querySelector(inputSelector)
+	input.className = isValid ? 'valid' : ''
 }
 
 async function saveOptions(event) {
 	event.preventDefault()
 	const apiKey = document.querySelector(apiKeyInputSelector).value
 	await saveSetting('apiKey', apiKey)
-	validateInput(apiKey)
+	validateInput(apiKey, apiKeyInputSelector)
+	const searchQuery = document.querySelector(searchQueryInputSelector).value
+	await saveSetting('searchQuery', searchQuery)
 	const messageElement = document.querySelector('#message')
 	messageElement.classList.add('success')
 	messageElement.textContent = 'Saved!'
@@ -21,12 +36,6 @@ async function saveOptions(event) {
 		messageElement.textContent = ''
 		messageElement.classList.remove('success')
 	}, 1_000)
-}
-
-function validateInput(apiKeyValue) {
-	const isValid = !!apiKeyValue
-	const apiKeyInput = document.querySelector(apiKeyInputSelector)
-	apiKeyInput.className = isValid ? 'valid' : ''
 }
 
 document.addEventListener('DOMContentLoaded', restoreOptions)

--- a/src/popup/index.js
+++ b/src/popup/index.js
@@ -8,47 +8,43 @@ async function initialize() {
 	await reloadItems()
 }
 
-function showApiKeyMissingPage() {
-	const page = document.getElementById('api-key-missing')
-	page.style = 'display: flex;'
+function showState(elementId) {
+	const element = document.getElementById(elementId)
+	element.style = 'display: flex;'
 }
 
-function hideApiKeyMissingPage() {
-	const page = document.getElementById('api-key-missing')
-	page.style = 'display: none;'
-}
-
-function showLoadingState() {
-	const loadingContainer = document.getElementById('loading')
-	loadingContainer.style = 'display: flex;'
-}
-
-function hideLoadingState() {
-	const loadingContainer = document.getElementById('loading')
-	loadingContainer.style = 'display: none;'
+function hideState(elementId) {
+	const element = document.getElementById(elementId)
+	element.style = 'display: none;'
 }
 
 async function reloadItems() {
 	const apiKey = await loadSetting('apiKey')
 	if (!apiKey) {
-		showApiKeyMissingPage()
+		showState('api-key-missing')
 		return
 	}
-	hideApiKeyMissingPage()
-	showLoadingState()
+	hideState('api-key-missing')
+	hideState('error')
+	showState('loading')
 	const content = document.getElementById('content')
 	content.textContent = ''
 	const list = document.createElement('ul')
-	const labels = await loadLabels()
-	const items = await loadItems()
-	items.forEach((item) => {
-		const listItem = document.createElement('li')
-		const itemNode = buildItemNode(item.node, reloadItems, labels)
-		listItem.appendChild(itemNode)
-		list.appendChild(listItem)
-	})
-	content.appendChild(list)
-	hideLoadingState()
+	try {
+		const labels = await loadLabels()
+		const items = await loadItems()
+		items.forEach((item) => {
+			const listItem = document.createElement('li')
+			const itemNode = buildItemNode(item.node, reloadItems, labels)
+			listItem.appendChild(itemNode)
+			list.appendChild(listItem)
+		})
+		content.appendChild(list)
+		hideState('loading')
+	} catch (error) {
+		hideState('loading')
+		showState('error')
+	}
 }
 
 document.addEventListener('DOMContentLoaded', initialize)

--- a/src/popup/index.js
+++ b/src/popup/index.js
@@ -25,21 +25,26 @@ async function reloadItems() {
 		return
 	}
 	hideState('api-key-missing')
+	hideState('no-items')
 	hideState('error')
 	showState('loading')
 	const content = document.getElementById('content')
 	content.textContent = ''
-	const list = document.createElement('ul')
 	try {
 		const labels = await loadLabels()
 		const items = await loadItems()
-		items.forEach((item) => {
-			const listItem = document.createElement('li')
-			const itemNode = buildItemNode(item.node, reloadItems, labels)
-			listItem.appendChild(itemNode)
-			list.appendChild(listItem)
-		})
-		content.appendChild(list)
+		if (items.length) {
+			const list = document.createElement('ul')
+			items.forEach((item) => {
+				const listItem = document.createElement('li')
+				const itemNode = buildItemNode(item.node, reloadItems, labels)
+				listItem.appendChild(itemNode)
+				list.appendChild(listItem)
+			})
+			content.appendChild(list)
+		} else {
+			showState('no-items')
+		}
 		hideState('loading')
 	} catch (error) {
 		hideState('loading')

--- a/src/popup/index.js
+++ b/src/popup/index.js
@@ -1,6 +1,6 @@
 import browser from 'webextension-polyfill'
 import { addLink, loadItems, loadLabels } from '../services/api'
-import { loadApiKey } from '../services/storage'
+import { loadSetting } from '../services/storage'
 import { getActiveTab, openTab } from '../services/tabs'
 import { buildItemNode } from './ui'
 
@@ -29,7 +29,7 @@ function hideLoadingState() {
 }
 
 async function reloadItems() {
-	const apiKey = await loadApiKey()
+	const apiKey = await loadSetting('apiKey')
 	if (!apiKey) {
 		showApiKeyMissingPage()
 		return

--- a/src/services/api.js
+++ b/src/services/api.js
@@ -1,4 +1,4 @@
-import { loadApiKey } from './storage'
+import { loadSetting } from './storage'
 
 const API_URL = 'https://api-prod.omnivore.app/api/graphql'
 
@@ -96,7 +96,7 @@ const searchQuery = `
     }`
 
 async function sendAPIRequest(query, variables) {
-	const apiKey = await loadApiKey()
+	const apiKey = await loadSetting('apiKey')
 	if (!apiKey) {
 		return
 	}

--- a/src/services/api.js
+++ b/src/services/api.js
@@ -113,7 +113,7 @@ async function sendAPIRequest(query, variables) {
 }
 
 export async function loadItems() {
-	const query = 'in:inbox'
+	const query = await loadSetting('searchQuery')
 	const data = await sendAPIRequest(searchQuery, {
 		first: 10,
 		query: query,

--- a/src/services/api.js
+++ b/src/services/api.js
@@ -113,7 +113,11 @@ async function sendAPIRequest(query, variables) {
 }
 
 export async function loadItems() {
-	const data = await sendAPIRequest(searchQuery, { first: 10 })
+	const query = 'in:inbox'
+	const data = await sendAPIRequest(searchQuery, {
+		first: 10,
+		query: query,
+	})
 	const edges = data.search.edges
 	return edges
 }

--- a/src/services/storage.js
+++ b/src/services/storage.js
@@ -1,22 +1,30 @@
 import browser from 'webextension-polyfill'
 
-export async function loadApiKey() {
+const settingKeys = ['apiKey']
+
+export async function loadSetting(settingKey) {
+	if (!settingKeys.includes(settingKey)) {
+		throw new Error('Invalid setting key')
+	}
 	function onGot(result) {
-		return Promise.resolve(result.apiKey)
+		return Promise.resolve(result[settingKey])
 	}
 	function onError(error) {
 		return Promise.reject(error)
 	}
-	const getting = browser.storage.sync.get('apiKey')
+	const getting = browser.storage.sync.get(settingKey)
 	return getting.then(onGot, onError)
 }
 
-export async function saveApiKey(apiKey) {
-	function onSet(result) {
-		return Promise.resolve(result.apiKey)
+export async function saveSetting(settingKey, settingValue) {
+	if (!settingKeys.includes(settingKey)) {
+		throw new Error('Invalid setting key')
+	}
+	function onSet() {
+		return Promise.resolve()
 	}
 	function onError(error) {
 		return Promise.reject(error)
 	}
-	browser.storage.sync.set({ apiKey }).then(onSet, onError)
+	browser.storage.sync.set({ [settingKey]: settingValue }).then(onSet, onError)
 }

--- a/src/services/storage.js
+++ b/src/services/storage.js
@@ -1,11 +1,14 @@
 import browser from 'webextension-polyfill'
 
-const settingKeys = ['apiKey']
-
-export async function loadSetting(settingKey) {
+function checkSettingKey(settingKey) {
+	const settingKeys = ['apiKey']
 	if (!settingKeys.includes(settingKey)) {
 		throw new Error('Invalid setting key')
 	}
+}
+
+export async function loadSetting(settingKey) {
+	checkSettingKey(settingKey)
 	function onGot(result) {
 		return Promise.resolve(result[settingKey])
 	}
@@ -17,9 +20,7 @@ export async function loadSetting(settingKey) {
 }
 
 export async function saveSetting(settingKey, settingValue) {
-	if (!settingKeys.includes(settingKey)) {
-		throw new Error('Invalid setting key')
-	}
+	checkSettingKey(settingKey)
 	function onSet() {
 		return Promise.resolve()
 	}

--- a/src/services/storage.js
+++ b/src/services/storage.js
@@ -1,7 +1,11 @@
 import browser from 'webextension-polyfill'
 
+const defaultSettings = {
+	searchQuery: 'in:inbox',
+}
+
 function checkSettingKey(settingKey) {
-	const settingKeys = ['apiKey']
+	const settingKeys = ['apiKey', 'searchQuery']
 	if (!settingKeys.includes(settingKey)) {
 		throw new Error('Invalid setting key')
 	}
@@ -9,8 +13,14 @@ function checkSettingKey(settingKey) {
 
 export async function loadSetting(settingKey) {
 	checkSettingKey(settingKey)
-	function onGot(result) {
-		return Promise.resolve(result[settingKey])
+	async function onGot(result) {
+		const value = result[settingKey]
+		const defaultValue = defaultSettings[settingKey]
+		if (value === undefined && defaultValue) {
+			await saveSetting(settingKey, defaultValue)
+			return Promise.resolve(defaultValue)
+		}
+		return Promise.resolve(value)
 	}
 	function onError(error) {
 		return Promise.reject(error)


### PR DESCRIPTION
# Customizable query for search

Makes it possible to customize the `query` that is being used for the list view (e.g. for filtering or sorting) and sets the default query to `in:inbox`. Also makes the storage and options management more generic to prepare for more settings.

![Bildschirmfoto 2023-12-11 um 11 26 17](https://github.com/herrherrmann/omnivore-list-popup/assets/6429568/ef9836f6-50b5-4f2f-8e94-7dd04a15d71e)

# Error state

Adds an error state when fetching data fails (e.g. when entering an invalid search query):

![Bildschirmfoto 2023-12-11 um 15 53 04](https://github.com/herrherrmann/omnivore-list-popup/assets/6429568/386db52a-89b3-4c27-ba89-4b7ec899128e)


# Empty state

Adds an empty state for when the query does not return any items:

![Bildschirmfoto 2023-12-11 um 15 51 47](https://github.com/herrherrmann/omnivore-list-popup/assets/6429568/c62629fa-331d-49e9-9070-5a0901d7947c)
