### PR TITLE
Properly hide labels page in initial state (without api key)

### DIFF
--- a/src/popup/index.js
+++ b/src/popup/index.js
@@ -21,17 +21,18 @@ function hideState(elementId) {
 let currentPage = 1
 
 async function reloadItems() {
-	const apiKey = await loadSetting('apiKey')
-	if (!apiKey) {
-		showState('api-key-missing')
-		return
-	}
 	hideState('api-key-missing')
 	hideState('no-items')
 	hideState('error')
 	hideState('labels-page')
 	hideState('content')
 	showState('loading')
+	const apiKey = await loadSetting('apiKey')
+	if (!apiKey) {
+		hideState('loading')
+		showState('api-key-missing')
+		return
+	}
 	const content = document.getElementById('content')
 	content.textContent = ''
 	try {
@@ -57,6 +58,7 @@ async function reloadItems() {
 				content.appendChild(pagination)
 			}
 		} else {
+			hideState('loading')
 			showState('no-items')
 		}
 		hideState('loading')


### PR DESCRIPTION
Fixes the initialization of the popup.

<table>
<tr>
 <th>Before
 <th>After
<tr>
 <td><img src="https://github.com/herrherrmann/omnivore-list-popup/assets/6429568/efbf0c54-907f-4e5f-a5e5-056400dd9294" />
 <td><img src="https://github.com/herrherrmann/omnivore-list-popup/assets/6429568/be270cb0-1849-434c-a513-b0d2ab4c2b91" />
</table>