### PR TITLE
Display labels in modal instead of separate page

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,5 +1,6 @@
 webpack.config.js
 
 # output files
+/background.js
 /options.js
 /popup.js

--- a/.stylelintrc.json
+++ b/.stylelintrc.json
@@ -1,6 +1,7 @@
 {
 	"extends": "stylelint-config-standard-scss",
 	"rules": {
+		"alpha-value-notation": null,
 		"declaration-empty-line-before": null,
 		"color-function-notation": null,
 		"color-hex-length": null,

--- a/popup.css
+++ b/popup.css
@@ -14,18 +14,7 @@ body {
 	font-size: 13px;
 }
 
-.toolbar {
-	display: flex;
-	gap: 5px;
-	padding: var(--outer-padding);
-	background-color: var(--card-background);
-	border-bottom: 1px solid var(--border-color);
-}
-
-.toolbar button {
-	display: flex;
-	align-items: center;
-	gap: 3px;
+.button {
 	font: inherit;
 	padding: var(--button-paddings);
 	background-color: var(--card-background);
@@ -34,18 +23,33 @@ body {
 	cursor: pointer;
 }
 
-.toolbar button:hover {
+.button:hover {
 	background-color: var(--card-background-hover);
 }
 
-.toolbar button:disabled {
+.button:disabled {
 	opacity: 0.8;
 	cursor: wait;
 }
 
-.toolbar button svg {
+.button:has(svg) {
+	display: flex;
+	align-items: center;
+	gap: 3px;
+}
+
+.button svg {
 	width: 1.2em;
+	vertical-align: -0.125em;
 	pointer-events: none;
+}
+
+.toolbar {
+	display: flex;
+	gap: 5px;
+	padding: var(--outer-padding);
+	background-color: var(--card-background);
+	border-bottom: 1px solid var(--border-color);
 }
 
 .loading {
@@ -71,21 +75,6 @@ body {
 	gap: 10px;
 	padding: var(--outer-padding);
 	min-height: 150px;
-}
-
-.api-key-missing button,
-.error button {
-	font: inherit;
-	padding: var(--button-paddings);
-	background-color: var(--card-background);
-	border: 1px solid var(--border-color);
-	border-radius: var(--border-radius);
-	cursor: pointer;
-}
-
-.api-key-missing button:hover,
-.error button:hover {
-	background-color: var(--card-background-hover);
 }
 
 @keyframes rotate {
@@ -218,20 +207,6 @@ li:last-of-type {
 	background: var(--buttons-container-background);
 }
 
-.item .buttons button {
-	display: flex;
-	font: inherit;
-	padding: var(--button-paddings);
-	background-color: var(--card-background);
-	border: 1px solid var(--border-color);
-	border-radius: var(--border-radius);
-	cursor: pointer;
-}
-
-.item .buttons button:hover {
-	background-color: var(--card-background-hover);
-}
-
 .item .buttons button svg {
 	width: 20px;
 	height: 20px;
@@ -250,26 +225,6 @@ li:last-of-type {
 	gap: 10px;
 }
 
-.pagination .buttons button {
-	font: inherit;
-	padding: var(--button-paddings);
-	background-color: var(--card-background);
-	border: 1px solid var(--border-color);
-	border-radius: var(--border-radius);
-	cursor: pointer;
-}
-
-.pagination .buttons button:hover {
-	background-color: var(--card-background-hover);
-}
-
-.pagination .buttons button svg {
-	width: 1.2em;
-	height: 1.2em;
-	vertical-align: -0.125em;
-	pointer-events: none;
-}
-
 .pagination .buttons .info {
 	font-size: 13px;
 	text-align: center;
@@ -286,6 +241,12 @@ li:last-of-type {
 	justify-content: center;
 	padding: 50px var(--outer-padding) var(--outer-padding) var(--outer-padding);
 	cursor: pointer;
+}
+
+@media (prefers-color-scheme: dark) {
+	.modal-overlay {
+		background-color: rgba(0, 0, 0, 0.5);
+	}
 }
 
 .modal {
@@ -376,20 +337,6 @@ li:last-of-type {
 #labels-modal #footer #buttons {
 	display: flex;
 	gap: 5px;
-}
-
-#labels-modal #footer #buttons button {
-	display: flex;
-	font: inherit;
-	padding: var(--button-paddings);
-	background-color: var(--card-background);
-	border: 1px solid var(--border-color);
-	border-radius: var(--border-radius);
-	cursor: pointer;
-}
-
-#labels-modal #footer #buttons button:hover {
-	background-color: var(--card-background-hover);
 }
 
 #labels-modal #footer #links a {

--- a/popup.css
+++ b/popup.css
@@ -6,6 +6,7 @@
 
 html,
 body {
+	position: relative;
 	width: 350px;
 	background-color: var(--background-color);
 	color: var(--text-color-primary);
@@ -97,8 +98,7 @@ body {
 	animation: rotate 1s linear 0s infinite;
 }
 
-.content,
-.labels-page {
+.content {
 	flex-direction: column;
 	max-height: 450px;
 	padding: var(--outer-padding);
@@ -276,57 +276,109 @@ li:last-of-type {
 	color: var(--text-color-secondary);
 }
 
-/* Labels page */
-#labels-page fieldset {
+/* Modals */
+.modal-overlay {
+	position: absolute;
+	inset: 0;
+	background-color: rgba(0, 0, 0, 0.2);
+	display: flex;
+	align-items: flex-start;
+	justify-content: center;
+	padding: 50px var(--outer-padding) var(--outer-padding) var(--outer-padding);
+	cursor: pointer;
+}
+
+.modal {
+	position: relative;
+	min-width: 80%;
+	background-color: var(--card-background);
+	border-radius: var(--border-radius);
+	box-shadow: 1px 1px 3px rgba(0, 0, 0, 0.25);
+	cursor: default;
+}
+
+.modal .modal-header {
+	display: flex;
+	gap: 5px;
+	justify-content: space-between;
+	align-items: center;
+	padding: 3px var(--modal-padding);
+	border-bottom: 1px solid var(--border-color);
+}
+
+.modal .modal-header .modal-title {
+	font-size: 15px;
+	font-weight: 600;
+}
+
+.modal .modal-header .modal-close-button {
+	padding: 3px;
+	border: none;
+	border-radius: var(--border-radius);
+	line-height: 1;
+	color: var(--text-color-primary);
+	background-color: transparent;
+	cursor: pointer;
+}
+
+.modal .modal-header .modal-close-button:hover {
+	background-color: var(--card-background-hover);
+}
+
+.modal .modal-body {
+	padding: var(--modal-padding);
+}
+
+#labels-modal fieldset {
 	width: 100%;
 	border: none;
 	padding: 0;
 }
 
-#labels-page legend {
+#labels-modal legend {
 	font-weight: 600;
 	margin: 0 0 5px 0;
 }
 
-#labels-page #labels {
+#labels-modal #labels {
 	margin: 0 0 15px 0;
 }
 
-#labels-page #labels .label {
+#labels-modal #labels .label {
 	display: flex;
 	gap: 5px;
 	margin: 0 0 5px 0;
 }
 
-#labels-page #labels .label label {
+#labels-modal #labels .label label {
 	display: flex;
 	align-items: center;
 	gap: 3px;
 }
 
-#labels-page #labels .label label .dot {
+#labels-modal #labels .label label .dot {
 	border-radius: 50%;
 	flex: 0 0 0.7em;
 	height: 0.7em;
 }
 
-#labels-page #labels .label label .name {
+#labels-modal #labels .label label .name {
 	flex: 1 0 auto;
 }
 
-#labels-page #footer {
+#labels-modal #footer {
 	display: flex;
 	justify-content: space-between;
 	align-items: center;
 	gap: 10px;
 }
 
-#labels-page #footer #buttons {
+#labels-modal #footer #buttons {
 	display: flex;
 	gap: 5px;
 }
 
-#labels-page #footer #buttons button {
+#labels-modal #footer #buttons button {
 	display: flex;
 	font: inherit;
 	padding: var(--button-paddings);
@@ -336,11 +388,11 @@ li:last-of-type {
 	cursor: pointer;
 }
 
-#labels-page #footer #buttons button:hover {
+#labels-modal #footer #buttons button:hover {
 	background-color: var(--card-background-hover);
 }
 
-#labels-page #footer #links a {
+#labels-modal #footer #links a {
 	display: flex;
 	align-items: center;
 	gap: 3px;
@@ -348,10 +400,20 @@ li:last-of-type {
 	text-decoration: none;
 }
 
-#labels-page #footer #links a svg {
+#labels-modal #footer #links a svg {
 	width: 1em;
 }
 
-#labels-page #footer #links a:hover {
+#labels-modal #footer #links a:hover {
 	text-decoration: underline;
+}
+
+/* Screenreader-only content, source: https://webaim.org/techniques/css/invisiblecontent/ */
+.sr-only {
+	position: absolute;
+	left: -10000px;
+	top: auto;
+	width: 1px;
+	height: 1px;
+	overflow: hidden;
 }

--- a/popup.css
+++ b/popup.css
@@ -303,7 +303,9 @@ li:last-of-type {
 }
 
 #labels-modal #labels {
-	margin: 0 0 15px 0;
+	margin: 0 0 5px 0;
+	max-height: 60vh;
+	overflow: auto;
 }
 
 #labels-modal #labels .label {

--- a/popup.css
+++ b/popup.css
@@ -16,6 +16,7 @@ body {
 
 .button {
 	font: inherit;
+	color: inherit;
 	padding: var(--button-paddings);
 	background-color: var(--card-background);
 	border: 1px solid var(--border-color);
@@ -23,12 +24,12 @@ body {
 	cursor: pointer;
 }
 
-.button:hover {
+.button:not(:disabled):hover {
 	background-color: var(--card-background-hover);
 }
 
 .button:disabled {
-	opacity: 0.8;
+	opacity: 0.5;
 	cursor: wait;
 }
 

--- a/popup.html
+++ b/popup.html
@@ -131,38 +131,74 @@
 			No items found.
 		</div>
 		<div class="content" id="content"></div>
-		<div class="labels-page" id="labels-page">
-			<form>
-				<fieldset>
-					<legend>Select labels:</legend>
-					<div id="labels"></div>
-					<div id="footer">
-						<div id="buttons"></div>
-						<div id="links">
-							<a href="https://omnivore.app/settings/labels" target="_blank"
-								><svg
-									xmlns="http://www.w3.org/2000/svg"
-									width="20"
-									height="20"
-									viewBox="0 0 24 24"
-									fill="none"
-									stroke="currentColor"
-									stroke-width="1.5"
-									stroke-linecap="round"
-									stroke-linejoin="round"
-								>
-									<path
-										d="M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6"
-									/>
-									<polyline points="15 3 21 3 21 9" />
-									<line x1="10" x2="21" y1="14" y2="3" />
-								</svg>
-								Manage labels</a
+		<div
+			role="dialog"
+			aria-labelledby="labels-modal-title"
+			aria-hidden="true"
+			class="modal-overlay"
+			id="labels-modal"
+			style="display: none"
+		>
+			<div class="modal">
+				<div class="modal-header">
+					<h2 class="modal-title" id="labels-modal-title">Select labels</h2>
+					<div>
+						<button
+							type="button"
+							class="modal-close-button"
+							aria-label="Close modal"
+						>
+							<svg
+								xmlns="http://www.w3.org/2000/svg"
+								width="20"
+								height="20"
+								viewBox="0 0 24 24"
+								fill="none"
+								stroke="currentColor"
+								stroke-width="2"
+								stroke-linecap="round"
+								stroke-linejoin="round"
 							>
-						</div>
+								<path d="M18 6 6 18" />
+								<path d="m6 6 12 12" />
+							</svg>
+						</button>
 					</div>
-				</fieldset>
-			</form>
+				</div>
+				<div class="modal-body">
+					<form>
+						<fieldset>
+							<legend class="sr-only">Select labels:</legend>
+							<div id="labels"></div>
+							<div id="footer">
+								<div id="links">
+									<a href="https://omnivore.app/settings/labels" target="_blank"
+										><svg
+											xmlns="http://www.w3.org/2000/svg"
+											width="20"
+											height="20"
+											viewBox="0 0 24 24"
+											fill="none"
+											stroke="currentColor"
+											stroke-width="1.5"
+											stroke-linecap="round"
+											stroke-linejoin="round"
+										>
+											<path
+												d="M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6"
+											/>
+											<polyline points="15 3 21 3 21 9" />
+											<line x1="10" x2="21" y1="14" y2="3" />
+										</svg>
+										Manage labels</a
+									>
+								</div>
+								<div id="buttons"></div>
+							</div>
+						</fieldset>
+					</form>
+				</div>
+			</div>
 		</div>
 
 		<script src="popup.js"></script>

--- a/popup.html
+++ b/popup.html
@@ -9,7 +9,7 @@
 
 	<body>
 		<header class="toolbar">
-			<button type="button" class="add-current-page">
+			<button type="button" class="button add-current-page">
 				<svg
 					xmlns="http://www.w3.org/2000/svg"
 					width="20"
@@ -26,7 +26,7 @@
 				</svg>
 				Add this page
 			</button>
-			<button type="button" class="refresh">
+			<button type="button" class="button refresh">
 				<svg
 					xmlns="http://www.w3.org/2000/svg"
 					width="20"
@@ -45,7 +45,7 @@
 				</svg>
 				Refresh
 			</button>
-			<button type="button" class="open-omnivore">
+			<button type="button" class="button open-omnivore">
 				<svg
 					xmlns="http://www.w3.org/2000/svg"
 					width="100%"
@@ -104,12 +104,12 @@
 				<line x1="12" x2="12.01" y1="16" y2="16" />
 			</svg>
 			Error while fetching data.<br />Please check your extension settings.
-			<button type="button" class="open-settings">Open Settings</button>
+			<button type="button" class="button open-settings">Open Settings</button>
 		</div>
 		<div class="api-key-missing" id="api-key-missing">
 			Please add your Omnivore API key<br />
 			in the extension settings.
-			<button type="button" class="open-settings">Open Settings</button>
+			<button type="button" class="button open-settings">Open Settings</button>
 		</div>
 		<div class="no-items" id="no-items">
 			<svg

--- a/src/popup/modal.js
+++ b/src/popup/modal.js
@@ -1,0 +1,46 @@
+let currentModal = null
+
+/**
+ * Shows a modal with the specified DOM element id.
+ * @param {('labels-modal')} shownModalId
+ */
+export function showModal(shownModalId) {
+	currentModal = shownModalId
+	const overlay = document.getElementById(shownModalId)
+	overlay.style = 'display: flex;'
+	overlay.addEventListener('click', closeModalViaOverlay)
+	overlay.setAttribute('aria-hidden', false)
+	const closeButton = overlay.querySelector('.modal-close-button')
+	closeButton.addEventListener('click', closeCurrentModal)
+}
+
+/**
+ * @param {Event} clickEvent
+ */
+function closeModalViaOverlay(clickEvent) {
+	if (clickEvent.target.id === currentModal) {
+		closeModal(currentModal)
+	}
+	clickEvent.stopPropagation()
+}
+
+/**
+ * Closes the currently-shown modal.
+ */
+function closeCurrentModal() {
+	closeModal(currentModal)
+}
+
+/**
+ * Closes the modal with the specified DOM element id and removes all related event listeners.
+ * @param {('labels-modal')} modalId
+ */
+export function closeModal(modalId) {
+	const overlay = document.getElementById(modalId)
+	overlay.style = 'display: none'
+	overlay.setAttribute('aria-hidden', true)
+	overlay.removeEventListener('click', closeModalViaOverlay)
+	const closeButton = overlay.querySelector('.modal-close-button')
+	closeButton.removeEventListener('click', closeCurrentModal)
+	currentModal = null
+}

--- a/src/popup/ui.js
+++ b/src/popup/ui.js
@@ -245,6 +245,7 @@ function showLabelsModal(article, labels, onAfterUpdate) {
 
 	const cancelButton = document.createElement('button')
 	cancelButton.type = 'button'
+	cancelButton.className = 'button'
 	cancelButton.textContent = 'Cancel'
 	cancelButton.addEventListener('click', closeLabelsModal)
 	buttons.appendChild(cancelButton)
@@ -253,6 +254,7 @@ function showLabelsModal(article, labels, onAfterUpdate) {
 
 	const saveButton = document.createElement('button')
 	saveButton.type = 'submit'
+	saveButton.className = 'button'
 	saveButton.textContent = 'Save'
 	saveButton.addEventListener('click', async () => {
 		if (isSaving) {

--- a/src/popup/ui.js
+++ b/src/popup/ui.js
@@ -12,17 +12,17 @@ import {
 } from '../services/api'
 import { isMacOS } from '../services/system'
 import { openTab } from '../services/tabs'
+import { closeModal, showModal } from './modal'
 
 /**
  * Shows a certain UI state (similar to a page).
- * @param {('api-key-missing' | 'no-items' | 'error' | 'labels-page' | 'content' | 'loading')} shownStateId
+ * @param {('api-key-missing' | 'no-items' | 'error' | 'content' | 'loading')} shownStateId
  */
 export function showState(shownStateId) {
 	const stateIds = [
 		'api-key-missing',
 		'no-items',
 		'error',
-		'labels-page',
 		'content',
 		'loading',
 	]
@@ -143,7 +143,7 @@ function createButtonsDiv(node, labels, onAfterUpdate) {
 	labelButton.addEventListener('click', async (event) => {
 		event.preventDefault()
 		event.stopPropagation()
-		showLabelsPage(node, labels, onAfterUpdate)
+		showLabelsModal(node, labels, onAfterUpdate)
 	})
 	buttons.appendChild(labelButton)
 
@@ -214,10 +214,12 @@ export function createPagination(pageInfo) {
 	return pagination
 }
 
-function showLabelsPage(article, labels, onAfterUpdate) {
-	showState('labels-page')
-	const labelsPage = document.getElementById('labels-page')
-	const labelsDiv = labelsPage.querySelector('#labels')
+function showLabelsModal(article, labels, onAfterUpdate) {
+	showModal('labels-modal')
+	const labelsModal = document.getElementById('labels-modal')
+
+	const labelsDiv = labelsModal.querySelector('#labels')
+	labelsDiv.innerHTML = ''
 
 	labels.forEach((item) => {
 		const div = document.createElement('div')
@@ -238,15 +240,13 @@ function showLabelsPage(article, labels, onAfterUpdate) {
 		labelsDiv.appendChild(div)
 	})
 
-	const buttons = labelsPage.querySelector('#buttons')
+	const buttons = labelsModal.querySelector('#buttons')
 	buttons.innerHTML = ''
 
 	const cancelButton = document.createElement('button')
 	cancelButton.type = 'button'
 	cancelButton.textContent = 'Cancel'
-	cancelButton.addEventListener('click', () => {
-		closeLabelsPage()
-	})
+	cancelButton.addEventListener('click', closeLabelsModal)
 	buttons.appendChild(cancelButton)
 
 	let isSaving = false
@@ -261,20 +261,19 @@ function showLabelsPage(article, labels, onAfterUpdate) {
 		isSaving = true
 		saveButton.disabled = true
 		cancelButton.disabled = true
-		const inputElements = labelsPage.querySelectorAll('#labels input')
+		const inputElements = labelsModal.querySelectorAll('#labels input')
 		const checkedValues = Array.from(inputElements)
 			.filter((inputElement) => inputElement.checked)
 			.map((inputElement) => inputElement.value)
 		await saveLabels(article.id, checkedValues)
 		// TODO: Error handling!
-		closeLabelsPage()
+		closeLabelsModal()
 		onAfterUpdate()
 	})
 	buttons.appendChild(saveButton)
 
-	function closeLabelsPage() {
-		labelsDiv.innerHTML = ''
-		showState('content')
+	function closeLabelsModal() {
+		closeModal('labels-modal')
 	}
 }
 

--- a/variables.css
+++ b/variables.css
@@ -34,7 +34,7 @@
 		--text-color-secondary: #cfcfd8;
 		--border-color: #42414d;
 		--card-background: #5b5b66;
-		--card-background-hover: #42414d;
+		--card-background-hover: #4d4d56;
 		--buttons-container-background: linear-gradient(
 			90deg,
 			rgba(251, 251, 254, 0%) 0%,

--- a/variables.css
+++ b/variables.css
@@ -14,6 +14,7 @@
 	);
 
 	--outer-padding: 5px;
+	--modal-padding: 6px;
 	--button-paddings: 3px 6px;
 	--border-radius: 5px;
 


### PR DESCRIPTION
Labels are now shown in a modal, which makes the state UX a bit easier to understand.

Also improves the button styles, especially their hover and disabled states.

<img width="358" alt="Labels modal" src="https://github.com/herrherrmann/omnivore-list-popup/assets/6429568/ef418273-624e-4ec0-a539-854989514f96">
