### PR TITLE
Catch errors when adding items via keyboard shortcut

### DIFF
--- a/src/popup/index.js
+++ b/src/popup/index.js
@@ -89,8 +89,13 @@ document.addEventListener('click', async (event) => {
 	element.disabled = true
 	if (element.classList.contains('add-current-page')) {
 		const activeTab = await getActiveTab()
-		await addLink(activeTab.url)
-		await reloadItems()
+		try {
+			await addLink(activeTab.url)
+		} catch (error) {
+			// TODO: Indicate error in UI.
+		} finally {
+			await reloadItems()
+		}
 	}
 	if (element.classList.contains('refresh')) {
 		setLoadingState(true)

--- a/src/services/api.js
+++ b/src/services/api.js
@@ -112,8 +112,15 @@ export async function addLink(url) {
 			clientRequestId: generateUUID(),
 		},
 	}
-	// TODO: Error handling!
-	await sendAPIRequest(query, variables)
+	const response = await sendAPIRequest(query, variables)
+	if (hasResponseError(response.saveUrl)) {
+		throw new Error('adding link failed')
+	}
+	return response
+}
+
+function hasResponseError(responseBody) {
+	return responseBody.errorCodes?.length > 0
 }
 
 export async function archiveLink(linkId) {


### PR DESCRIPTION
Adds the first layer of error handling, so the badge icon can react properly when adding a new link failed.