### PR TITLE
Fix open without visit

### DIFF
--- a/src/services/tabs.ts
+++ b/src/services/tabs.ts
@@ -15,6 +15,6 @@ export async function getActiveTab() {
 	return querying.then(onGot, onError)
 }
 
-export function openTab(url: string) {
-	return browser.tabs.create({ url })
+export function openTab(url: string, active = true) {
+	return browser.tabs.create({ url, active: active })
 }

--- a/src/services/ui.ts
+++ b/src/services/ui.ts
@@ -77,7 +77,7 @@ export function buildItemNode(
 	item.setAttribute('href', node.url)
 	item.addEventListener('click', (event) => {
 		event.preventDefault()
-		openTab(node.url)
+		openTab(node.url, !shouldKeepPopupOpen(event))
 		if (!shouldKeepPopupOpen(event)) {
 			window.close()
 		}


### PR DESCRIPTION
Fixes issue where Cmd-click (macOS) and Ctrl-click (Windows) would still close the popup.

This is because the newly open opened tab would become active by default.